### PR TITLE
Enhance trip planner UX

### DIFF
--- a/src/components/AnimatedInput.tsx
+++ b/src/components/AnimatedInput.tsx
@@ -1,6 +1,6 @@
 // src/components/AnimatedInput.tsx
 import React, { useState } from "react";
-import { motion, AnimatePresence } from "framer-motion";
+import { motion } from "framer-motion";
 
 interface AnimatedInputProps {
   label: string;
@@ -10,12 +10,10 @@ interface AnimatedInputProps {
 
 const AnimatedInput: React.FC<AnimatedInputProps> = ({ label, placeholder, onSubmit }) => {
   const [inputValue, setInputValue] = useState("");
-  const [submitted, setSubmitted] = useState(false);
 
   const handleSubmit = () => {
     if (inputValue.trim() === "") return;
-    setSubmitted(true);
-    setTimeout(() => onSubmit(inputValue), 800); // give animation time
+    onSubmit(inputValue);
   };
 
   return (
@@ -28,43 +26,27 @@ const AnimatedInput: React.FC<AnimatedInputProps> = ({ label, placeholder, onSub
         {label}
       </motion.h2>
 
-      <AnimatePresence>
-        {!submitted ? (
-          <motion.div
-            key="input"
-            initial={{ opacity: 0, y: 10 }}
-            animate={{ opacity: 1, y: 0 }}
-            exit={{ opacity: 0, scale: 0.95 }}
-            transition={{ duration: 0.4 }}
-            className="flex flex-col gap-3"
-          >
-            <input
-              type="text"
-              className="w-full px-4 py-3 rounded-xl border border-gray-300 shadow-sm focus:outline-none focus:ring-2 focus:ring-indigo-400 transition"
-              placeholder={placeholder}
-              value={inputValue}
-              onChange={(e) => setInputValue(e.target.value)}
-              onKeyDown={(e) => e.key === "Enter" && handleSubmit()}
-            />
-            <button
-              onClick={handleSubmit}
-              className="self-center px-5 py-2 bg-indigo-600 text-white rounded-xl shadow hover:bg-indigo-700 transition"
-            >
-              Next
-            </button>
-          </motion.div>
-        ) : (
-          <motion.div
-            key="submitted"
-            initial={{ opacity: 0, scale: 0.8 }}
-            animate={{ opacity: 1, scale: 1 }}
-            exit={{ opacity: 0 }}
-            className="text-center text-2xl font-bold text-indigo-700"
-          >
-            {inputValue}
-          </motion.div>
-        )}
-      </AnimatePresence>
+      <motion.div
+        initial={{ opacity: 0, y: 10 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.4 }}
+        className="flex flex-col gap-3"
+      >
+        <input
+          type="text"
+          className="w-full px-4 py-3 rounded-xl border border-gray-300 shadow-sm focus:outline-none focus:ring-2 focus:ring-indigo-400 transition"
+          placeholder={placeholder}
+          value={inputValue}
+          onChange={(e) => setInputValue(e.target.value)}
+          onKeyDown={(e) => e.key === "Enter" && handleSubmit()}
+        />
+        <button
+          onClick={handleSubmit}
+          className="self-center px-5 py-2 bg-indigo-600 text-white rounded-xl shadow hover:bg-indigo-700 transition"
+        >
+          Next
+        </button>
+      </motion.div>
     </div>
   );
 };

--- a/src/components/PathwayConnector.tsx
+++ b/src/components/PathwayConnector.tsx
@@ -2,30 +2,44 @@
 import React from "react";
 import { motion } from "framer-motion";
 
-const PathwayConnector: React.FC = () => {
+interface PathwayConnectorProps {
+  direction: "left" | "right";
+}
+
+const PathwayConnector: React.FC<PathwayConnectorProps> = ({ direction }) => {
+  const pathD =
+    direction === "right"
+      ? "M40 0 V40 Q40 60 60 60 H80"
+      : "M40 0 V40 Q40 60 20 60 H0";
+  const circleCx = direction === "right" ? 80 : 0;
+
   return (
-    <motion.div
-      className="flex flex-col items-center my-6"
+    <motion.svg
+      width="80"
+      height="60"
+      className="text-indigo-400"
       initial={{ opacity: 0 }}
       animate={{ opacity: 1 }}
     >
-      {/* Line */}
-      <motion.div
-        className="w-1 bg-indigo-300"
-        style={{ height: "40px" }}
-        initial={{ scaleY: 0 }}
-        animate={{ scaleY: 1 }}
-        transition={{ duration: 0.4 }}
+      <motion.path
+        d={pathD}
+        fill="none"
+        stroke="#a5b4fc"
+        strokeWidth={2}
+        initial={{ pathLength: 0 }}
+        animate={{ pathLength: 1 }}
+        transition={{ duration: 0.6 }}
       />
-
-      {/* Dot */}
-      <motion.div
-        className="w-4 h-4 rounded-full bg-indigo-500 mt-1 shadow"
+      <motion.circle
+        cx={circleCx}
+        cy={60}
+        r={4}
+        fill="#6366f1"
         initial={{ scale: 0 }}
         animate={{ scale: 1 }}
-        transition={{ duration: 0.3, delay: 0.2 }}
+        transition={{ duration: 0.3, delay: 0.4 }}
       />
-    </motion.div>
+    </motion.svg>
   );
 };
 

--- a/src/components/TripStepCard.tsx
+++ b/src/components/TripStepCard.tsx
@@ -22,12 +22,12 @@ const TripStepCard: React.FC<TripStepCardProps> = ({
 }) => {
   return (
     <motion.div
-      className="bg-white rounded-2xl shadow-lg overflow-hidden w-full max-w-2xl mx-auto"
+      className="bg-white rounded-2xl shadow-lg overflow-hidden w-72 sm:w-80"
       initial={{ opacity: 0, y: 20 }}
       animate={{ opacity: 1, y: 0 }}
       transition={{ duration: 0.5 }}
     >
-      <img src={imageUrl} alt={title} className="w-full h-56 object-cover" />
+      <img src={imageUrl} alt={title} className="w-full h-40 object-cover" />
 
       <div className="p-5">
         <p className="text-sm text-gray-500">{time}</p>

--- a/src/components/TripStepCardSkeleton.tsx
+++ b/src/components/TripStepCardSkeleton.tsx
@@ -1,0 +1,21 @@
+// src/components/TripStepCardSkeleton.tsx
+import React from "react";
+
+const TripStepCardSkeleton: React.FC = () => {
+  return (
+    <div className="bg-white rounded-2xl shadow-lg overflow-hidden w-72 sm:w-80 animate-pulse">
+      <div className="w-full h-40 bg-gray-200" />
+      <div className="p-4 space-y-3">
+        <div className="h-3 w-1/3 bg-gray-200 rounded" />
+        <div className="h-4 w-2/3 bg-gray-200 rounded" />
+        <div className="h-3 w-1/2 bg-gray-200 rounded" />
+        <div className="flex gap-3 mt-4">
+          <div className="h-8 w-20 bg-gray-200 rounded-xl" />
+          <div className="h-8 w-20 bg-gray-200 rounded-xl" />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default TripStepCardSkeleton;

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -4,6 +4,8 @@ import AnimatedInput from "../components/AnimatedInput";
 import TagSelector from "../components/TagSelector";
 import TripStepCard from "../components/TripStepCard";
 import PathwayConnector from "../components/PathwayConnector";
+import TripStepCardSkeleton from "../components/TripStepCardSkeleton";
+import { ArrowLeft, Loader2 } from "lucide-react";
 import { generateTripPlan } from "../api/openai";
 import { fetchImageFromGoogle } from "../api/googleImage";
 
@@ -28,6 +30,14 @@ const Home: React.FC = () => {
   const [loading, setLoading] = useState(false);
 
   const handleNext = () => setStep((prev) => prev + 1);
+  const handleBack = () => setStep((prev) => Math.max(1, prev - 1));
+  const handleReset = () => {
+    setDestination("");
+    setDuration("");
+    setInterests([]);
+    setTripSteps([]);
+    setStep(1);
+  };
 
   const handleCreateTrip = async () => {
     setLoading(true);
@@ -69,7 +79,17 @@ const Home: React.FC = () => {
   };
 
   return (
-    <div className="flex flex-col items-center justify-center py-20 px-4">
+    <div className="flex flex-col items-center justify-center py-20 px-4 relative">
+      {step > 1 && step <= 4 && (
+        <button
+          onClick={handleBack}
+          className="absolute top-4 left-4 text-gray-600 hover:text-gray-800"
+          aria-label="Go back"
+        >
+          <ArrowLeft className="w-6 h-6" />
+        </button>
+      )}
+
       <h1 className="text-4xl font-bold mb-8 text-center">Plan Your Perfect Trip</h1>
 
       {/* Display chosen details */}
@@ -126,31 +146,61 @@ const Home: React.FC = () => {
       )}
 
       {step === 4 && (
-        <button
-          onClick={handleCreateTrip}
-          className="mt-8 px-6 py-3 bg-indigo-600 text-white font-semibold rounded-xl shadow-md hover:bg-indigo-700 transition"
-        >
-          {loading ? "Creating your trip..." : "Create My Trip ✈️"}
-        </button>
+        <div className="flex flex-col items-center w-full">
+          <button
+            onClick={handleCreateTrip}
+            disabled={loading}
+            className="mt-8 px-6 py-3 bg-indigo-600 text-white font-semibold rounded-xl shadow-md hover:bg-indigo-700 transition flex items-center gap-2 disabled:opacity-70"
+          >
+            {loading && <Loader2 className="w-5 h-5 animate-spin" />}
+            {loading ? "Creating your trip..." : "Create My Trip ✈️"}
+          </button>
+          {loading && (
+            <div className="w-full max-w-3xl flex flex-col items-center mt-10 gap-10">
+              {[0, 1, 2].map((i) => (
+                <React.Fragment key={i}>
+                  <div
+                    className={`w-full flex ${i % 2 === 0 ? "justify-start" : "justify-end"}`}
+                  >
+                    <TripStepCardSkeleton />
+                  </div>
+                  {i < 2 && (
+                    <PathwayConnector direction={i % 2 === 0 ? "right" : "left"} />
+                  )}
+                </React.Fragment>
+              ))}
+            </div>
+          )}
+        </div>
       )}
 
       {step === 5 && (
         <div className="w-full max-w-3xl flex flex-col items-center mt-10 gap-10">
-          {tripSteps.map((step, i) => (
-            <div key={i} className="w-full">
-              <TripStepCard
-                time={step.time}
-                title={step.title}
-                location={step.location}
-                imageUrl={
-                  step.imageUrl || "https://source.unsplash.com/800x400/?travel"
-                }
-                mapsLink={step.mapsLink}
-                websiteLink={step.websiteLink}
-              />
-              {i < tripSteps.length - 1 && <PathwayConnector />}
-            </div>
+          {tripSteps.map((s, i) => (
+            <React.Fragment key={i}>
+              <div
+                className={`w-full flex ${i % 2 === 0 ? "justify-start" : "justify-end"}`}
+              >
+                <TripStepCard
+                  time={s.time}
+                  title={s.title}
+                  location={s.location}
+                  imageUrl={s.imageUrl || "https://source.unsplash.com/800x400/?travel"}
+                  mapsLink={s.mapsLink}
+                  websiteLink={s.websiteLink}
+                />
+              </div>
+              {i < tripSteps.length - 1 && (
+                <PathwayConnector direction={i % 2 === 0 ? "right" : "left"} />
+              )}
+            </React.Fragment>
           ))}
+          <button
+            onClick={handleReset}
+            className="mt-4 px-6 py-3 bg-indigo-600 text-white font-semibold rounded-xl shadow-md hover:bg-indigo-700 transition"
+          >
+            Start New Trip
+          </button>
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary
- smooth step transitions and smaller trip cards with serpentine connectors
- navigation, loading spinner, skeleton placeholders, and reset option for trip creation

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6892010a45b0833292ddd9a186315699