### PR TITLE
Add app title and diagonal connectors; avoid Instagram images

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React + TS</title>
+    <title>Trip Creator</title>
   </head>
   <body>
     <div id="root"></div>

--- a/src/api/googleImage.ts
+++ b/src/api/googleImage.ts
@@ -6,11 +6,15 @@ export async function fetchImageFromGoogle(query: string): Promise<string | null
   const res = await fetch(
     `https://www.googleapis.com/customsearch/v1?q=${encodeURIComponent(
       query
-    )}&cx=${cx}&searchType=image&num=1&key=${apiKey}`
+    )}&cx=${cx}&searchType=image&num=10&key=${apiKey}`
   );
 
   const data = await res.json();
 
-  const image = data.items?.[0]?.link;
+  const image = data.items?.find((item: { link?: string }) => {
+    const link = (item.link || "").toLowerCase();
+    return !link.includes("instagram");
+  })?.link;
+
   return image || null;
 }

--- a/src/components/PathwayConnector.tsx
+++ b/src/components/PathwayConnector.tsx
@@ -8,15 +8,14 @@ interface PathwayConnectorProps {
 
 const PathwayConnector: React.FC<PathwayConnectorProps> = ({ direction }) => {
   const pathD =
-    direction === "right"
-      ? "M40 0 V40 Q40 60 60 60 H80"
-      : "M40 0 V40 Q40 60 20 60 H0";
-  const circleCx = direction === "right" ? 80 : 0;
+    direction === "right" ? "M44 0 L84 40" : "M44 0 L4 40";
+  const circleCx = direction === "right" ? 84 : 4;
 
   return (
     <motion.svg
-      width="80"
-      height="60"
+      width="88"
+      height="44"
+      viewBox="0 0 88 44"
       className="text-indigo-400"
       initial={{ opacity: 0 }}
       animate={{ opacity: 1 }}
@@ -32,7 +31,7 @@ const PathwayConnector: React.FC<PathwayConnectorProps> = ({ direction }) => {
       />
       <motion.circle
         cx={circleCx}
-        cy={60}
+        cy={40}
         r={4}
         fill="#6366f1"
         initial={{ scale: 0 }}

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -90,7 +90,8 @@ const Home: React.FC = () => {
         </button>
       )}
 
-      <h1 className="text-4xl font-bold mb-8 text-center">Plan Your Perfect Trip</h1>
+      <h1 className="text-5xl font-extrabold text-center mb-2">Trip Creator</h1>
+      <p className="text-4xl font-bold mb-8 text-center">Plan Your Perfect Trip</p>
 
       {/* Display chosen details */}
       <div className="flex flex-wrap gap-3 mb-8 justify-center">


### PR DESCRIPTION
## Summary
- update Google image search to skip Instagram links
- redesign timeline connector with 45° diagonal path and fix clipping
- add "Trip Creator" title in UI and browser tab

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689206eacf84833288969124e221cd24