### PR TITLE
Add sticky itinerary progress timeline

### DIFF
--- a/src/components/ProgressTimeline.tsx
+++ b/src/components/ProgressTimeline.tsx
@@ -1,0 +1,77 @@
+import React, { useEffect, useState } from "react";
+
+interface StepItem {
+  day: number;
+  title: string;
+  location: string;
+}
+
+interface ProgressTimelineProps {
+  steps: StepItem[];
+}
+
+const ProgressTimeline: React.FC<ProgressTimelineProps> = ({ steps }) => {
+  const [activeIndex, setActiveIndex] = useState(0);
+
+  useEffect(() => {
+    const observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            const idx = Number((entry.target as HTMLElement).dataset.stepIndex);
+            setActiveIndex((prev) => Math.max(prev, idx));
+          }
+        });
+      },
+      { threshold: 0.6 }
+    );
+
+    const elements = document.querySelectorAll("[data-step-index]");
+    elements.forEach((el) => observer.observe(el));
+
+    return () => observer.disconnect();
+  }, [steps]);
+
+  const progress = ((activeIndex + 1) / steps.length) * 100;
+
+  const firstIndexByDay = new Map<number, number>();
+  steps.forEach((s, i) => {
+    if (!firstIndexByDay.has(s.day)) {
+      firstIndexByDay.set(s.day, i);
+    }
+  });
+
+  return (
+    <div className="fixed left-4 top-24 bottom-24 w-6 z-10">
+      <div className="relative h-full w-1 bg-gray-200 rounded-full">
+        <div
+          className="absolute left-0 top-0 w-full bg-indigo-500 rounded-full"
+          style={{ height: `${progress}%` }}
+        />
+        {steps.map((s, i) => {
+          const isDayStart = firstIndexByDay.get(s.day) === i;
+          const size = isDayStart ? "w-3 h-3" : "w-2 h-2";
+          const top = (i / (steps.length - 1)) * 100;
+          const label = isDayStart ? `Day ${s.day}` : `${s.title} - ${s.location}`;
+          return (
+            <div
+              key={i}
+              title={label}
+              onClick={() => {
+                const el = document.querySelector(
+                  `[data-step-index='${i}']`
+                );
+                el?.scrollIntoView({ behavior: "smooth", block: "start" });
+              }}
+              className={`absolute left-1/2 -translate-x-1/2 -translate-y-1/2 bg-white border-2 border-indigo-500 rounded-full cursor-pointer ${size}`}
+              style={{ top: `${top}%` }}
+            />
+          );
+        })}
+      </div>
+    </div>
+  );
+};
+
+export default ProgressTimeline;
+

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -5,6 +5,7 @@ import TagSelector from "../components/TagSelector";
 import TripStepCard from "../components/TripStepCard";
 import PathwayConnector from "../components/PathwayConnector";
 import TripStepCardSkeleton from "../components/TripStepCardSkeleton";
+import ProgressTimeline from "../components/ProgressTimeline";
 import { ArrowLeft, Loader2 } from "lucide-react";
 import { generateTripPlan } from "../api/openai";
 import { fetchImageFromGoogle } from "../api/googleImage";
@@ -176,33 +177,37 @@ const Home: React.FC = () => {
       )}
 
       {step === 5 && (
-        <div className="w-full max-w-3xl flex flex-col items-center mt-10 gap-10">
-          {tripSteps.map((s, i) => (
-            <React.Fragment key={i}>
-              <div
-                className={`w-full flex ${i % 2 === 0 ? "justify-start" : "justify-end"}`}
-              >
-                <TripStepCard
-                  time={s.time}
-                  title={s.title}
-                  location={s.location}
-                  imageUrl={s.imageUrl || "https://source.unsplash.com/800x400/?travel"}
-                  mapsLink={s.mapsLink}
-                  websiteLink={s.websiteLink}
-                />
-              </div>
-              {i < tripSteps.length - 1 && (
-                <PathwayConnector direction={i % 2 === 0 ? "right" : "left"} />
-              )}
-            </React.Fragment>
-          ))}
-          <button
-            onClick={handleReset}
-            className="mt-4 px-6 py-3 bg-indigo-600 text-white font-semibold rounded-xl shadow-md hover:bg-indigo-700 transition"
-          >
-            Start New Trip
-          </button>
-        </div>
+        <>
+          <ProgressTimeline steps={tripSteps} />
+          <div className="w-full max-w-3xl flex flex-col items-center mt-10 gap-10">
+            {tripSteps.map((s, i) => (
+              <React.Fragment key={i}>
+                <div
+                  data-step-index={i}
+                  className={`w-full flex ${i % 2 === 0 ? "justify-start" : "justify-end"}`}
+                >
+                  <TripStepCard
+                    time={s.time}
+                    title={s.title}
+                    location={s.location}
+                    imageUrl={s.imageUrl || "https://source.unsplash.com/800x400/?travel"}
+                    mapsLink={s.mapsLink}
+                    websiteLink={s.websiteLink}
+                  />
+                </div>
+                {i < tripSteps.length - 1 && (
+                  <PathwayConnector direction={i % 2 === 0 ? "right" : "left"} />
+                )}
+              </React.Fragment>
+            ))}
+            <button
+              onClick={handleReset}
+              className="mt-4 px-6 py-3 bg-indigo-600 text-white font-semibold rounded-xl shadow-md hover:bg-indigo-700 transition"
+            >
+              Start New Trip
+            </button>
+          </div>
+        </>
       )}
     </div>
   );


### PR DESCRIPTION
## Summary
- introduce `ProgressTimeline` component with intersection observer and interactive dots for days and activities
- integrate progress timeline into trip results view for easier navigation

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6899cdbf83288332b5c0d6b5b3543fd3