### PR TITLE
Refine progress timeline styling and image handling

### DIFF
--- a/src/api/googleImage.ts
+++ b/src/api/googleImage.ts
@@ -13,7 +13,7 @@ export async function fetchImageFromGoogle(query: string): Promise<string | null
 
   const image = data.items?.find((item: { link?: string }) => {
     const link = (item.link || "").toLowerCase();
-    return !link.includes("instagram");
+    return !link.includes("instagram") && !link.includes("facebook");
   })?.link;
 
   return image || null;

--- a/src/components/ProgressTimeline.tsx
+++ b/src/components/ProgressTimeline.tsx
@@ -51,8 +51,9 @@ const ProgressTimeline: React.FC<ProgressTimelineProps> = ({ steps }) => {
       const last = elements[elements.length - 1] as HTMLElement;
 
       const start = first.getBoundingClientRect().top + window.scrollY;
-      const end = last.getBoundingClientRect().bottom + window.scrollY;
-      const current = window.scrollY + window.innerHeight / 2;
+      const end =
+        last.getBoundingClientRect().bottom + window.scrollY - window.innerHeight;
+      const current = window.scrollY;
       const ratio = (current - start) / (end - start);
       setScrollProgress(Math.max(0, Math.min(1, ratio)));
     };
@@ -82,9 +83,9 @@ const ProgressTimeline: React.FC<ProgressTimelineProps> = ({ steps }) => {
 
   return (
     <div className="fixed left-8 top-24 bottom-24 w-8 z-10">
-      <div className="relative h-full w-2 bg-gray-200 rounded-full">
+      <div className="relative h-full w-2 bg-indigo-100 rounded-full">
         <div
-          className="absolute left-0 top-0 w-full bg-indigo-500 rounded-full transition-all duration-300 ease-out"
+          className="absolute left-0 top-0 w-full bg-indigo-600 rounded-full transition-all duration-300 ease-out"
           style={{ height: `${scrollProgress * 100}%` }}
         />
         {steps.map((s, i) => {
@@ -103,7 +104,7 @@ const ProgressTimeline: React.FC<ProgressTimelineProps> = ({ steps }) => {
                 );
                 el?.scrollIntoView({ behavior: "smooth", block: "start" });
               }}
-              className={`absolute left-1/2 -translate-x-1/2 -translate-y-1/2 bg-white border-2 border-indigo-500 rounded-full cursor-pointer ${size}`}
+              className={`absolute left-1/2 -translate-x-1/2 -translate-y-1/2 bg-white border-2 border-indigo-600 rounded-full shadow cursor-pointer ${size}`}
               style={{ top: `${top}%` }}
             />
           );
@@ -111,7 +112,7 @@ const ProgressTimeline: React.FC<ProgressTimelineProps> = ({ steps }) => {
 
         {activeStep && (
           <div
-            className="absolute left-full ml-4 -translate-y-1/2 bg-white shadow px-2 py-1 rounded text-xs text-gray-800 whitespace-nowrap"
+            className="absolute left-full ml-4 -translate-y-1/2 bg-indigo-600 text-white shadow-lg px-3 py-1 rounded-full text-xs whitespace-nowrap"
             style={{ top: `${scrollProgress * 100}%` }}
           >
             {activeLabel}

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -176,39 +176,39 @@ const Home: React.FC = () => {
         </div>
       )}
 
-      {step === 5 && (
-        <>
-          <ProgressTimeline steps={tripSteps} />
-          <div className="w-full max-w-3xl flex flex-col items-center mt-10 gap-10">
-            {tripSteps.map((s, i) => (
-              <React.Fragment key={i}>
-                <div
-                  data-step-index={i}
-                  className={`w-full flex ${i % 2 === 0 ? "justify-start" : "justify-end"}`}
-                >
-                  <TripStepCard
-                    time={s.time}
-                    title={s.title}
-                    location={s.location}
-                    imageUrl={s.imageUrl || "https://source.unsplash.com/800x400/?travel"}
-                    mapsLink={s.mapsLink}
-                    websiteLink={s.websiteLink}
-                  />
-                </div>
-                {i < tripSteps.length - 1 && (
-                  <PathwayConnector direction={i % 2 === 0 ? "right" : "left"} />
-                )}
-              </React.Fragment>
-            ))}
+        {step === 5 && (
+          <>
             <button
               onClick={handleReset}
-              className="mt-4 px-6 py-3 bg-indigo-600 text-white font-semibold rounded-xl shadow-md hover:bg-indigo-700 transition"
+              className="absolute top-4 right-4 px-6 py-3 bg-indigo-600 text-white font-semibold rounded-xl shadow-md hover:bg-indigo-700 transition"
             >
               Start New Trip
             </button>
-          </div>
-        </>
-      )}
+            <ProgressTimeline steps={tripSteps} />
+            <div className="w-full max-w-3xl flex flex-col items-center mt-10 gap-10">
+              {tripSteps.map((s, i) => (
+                <React.Fragment key={i}>
+                  <div
+                    data-step-index={i}
+                    className={`w-full flex ${i % 2 === 0 ? "justify-start" : "justify-end"}`}
+                  >
+                    <TripStepCard
+                      time={s.time}
+                      title={s.title}
+                      location={s.location}
+                      imageUrl={s.imageUrl || "https://source.unsplash.com/800x400/?travel"}
+                      mapsLink={s.mapsLink}
+                      websiteLink={s.websiteLink}
+                    />
+                  </div>
+                  {i < tripSteps.length - 1 && (
+                    <PathwayConnector direction={i % 2 === 0 ? "right" : "left"} />
+                  )}
+                </React.Fragment>
+              ))}
+            </div>
+          </>
+        )}
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- Skip Facebook-hosted images when fetching photos for itinerary items
- Restyle progress timeline with primary indigo color, improved tooltip, and accurate scroll tracking
- Relocate "Start New Trip" button to the top-right to avoid interfering with progress bar

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6899dc2dc1488332a6dbe8090578196e