### PR TITLE
Ensure progress timeline reaches final step when scrolling

### DIFF
--- a/src/components/ProgressTimeline.tsx
+++ b/src/components/ProgressTimeline.tsx
@@ -29,6 +29,9 @@ const ProgressTimeline: React.FC<ProgressTimelineProps> = ({ steps }) => {
           break;
         }
       }
+      if (window.innerHeight + window.scrollY >= document.body.offsetHeight - 1) {
+        idx = elements.length - 1;
+      }
       setActiveIndex(idx);
     };
 


### PR DESCRIPTION
## Summary
- ensure progress bar marks last step when the page bottom is reached

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6899e626678c8332b43e8dfc27e82e96