### PR TITLE
Randomize trip card placement with position-aware connectors

### DIFF
--- a/src/components/PathwayConnector.tsx
+++ b/src/components/PathwayConnector.tsx
@@ -3,13 +3,23 @@ import React from "react";
 import { motion } from "framer-motion";
 
 interface PathwayConnectorProps {
-  direction: "left" | "right";
+  from: "left" | "right";
+  to: "left" | "right";
 }
 
-const PathwayConnector: React.FC<PathwayConnectorProps> = ({ direction }) => {
-  const pathD =
-    direction === "right" ? "M44 0 L84 40" : "M44 0 L4 40";
-  const circleCx = direction === "right" ? 84 : 4;
+const PathwayConnector: React.FC<PathwayConnectorProps> = ({ from, to }) => {
+  let pathD = "";
+  if (from === "left" && to === "right") {
+    pathD = "M44 0 L84 40";
+  } else if (from === "right" && to === "left") {
+    pathD = "M44 0 L4 40";
+  } else if (from === "left" && to === "left") {
+    pathD = "M44 0 L44 20 L4 40";
+  } else {
+    pathD = "M44 0 L44 20 L84 40";
+  }
+
+  const circleCx = to === "right" ? 84 : 4;
 
   return (
     <motion.svg

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -27,6 +27,7 @@ const Home: React.FC = () => {
   const [duration, setDuration] = useState("");
   const [interests, setInterests] = useState<string[]>([]);
   const [tripSteps, setTripSteps] = useState<TripStep[]>([]);
+  const [cardPositions, setCardPositions] = useState<("left" | "right")[]>([]);
   const [step, setStep] = useState(1);
   const [loading, setLoading] = useState(false);
 
@@ -37,6 +38,7 @@ const Home: React.FC = () => {
     setDuration("");
     setInterests([]);
     setTripSteps([]);
+    setCardPositions([]);
     setStep(1);
   };
 
@@ -71,6 +73,9 @@ const Home: React.FC = () => {
       );
 
       setTripSteps(stepsWithImages);
+      setCardPositions(
+        stepsWithImages.map(() => (Math.random() < 0.5 ? "left" : "right"))
+      );
       setStep(5);
     } catch (err) {
       console.error("Trip generation failed:", err);
@@ -167,7 +172,10 @@ const Home: React.FC = () => {
                     <TripStepCardSkeleton />
                   </div>
                   {i < 2 && (
-                    <PathwayConnector direction={i % 2 === 0 ? "right" : "left"} />
+                    <PathwayConnector
+                      from={i % 2 === 0 ? "left" : "right"}
+                      to={i % 2 === 0 ? "right" : "left"}
+                    />
                   )}
                 </React.Fragment>
               ))}
@@ -193,7 +201,9 @@ const Home: React.FC = () => {
               <React.Fragment key={i}>
                 <div
                   data-step-index={i}
-                  className={`w-full flex ${i % 2 === 0 ? "justify-start" : "justify-end"}`}
+                  className={`w-full flex ${
+                    cardPositions[i] === "left" ? "justify-start" : "justify-end"
+                  }`}
                 >
                   <TripStepCard
                     time={s.time}
@@ -205,7 +215,10 @@ const Home: React.FC = () => {
                   />
                 </div>
                 {i < tripSteps.length - 1 && (
-                  <PathwayConnector direction={i % 2 === 0 ? "right" : "left"} />
+                  <PathwayConnector
+                    from={cardPositions[i]}
+                    to={cardPositions[i + 1]}
+                  />
                 )}
               </React.Fragment>
             ))}


### PR DESCRIPTION
## Summary
- Randomize each trip step's left/right placement when a plan is generated
- Draw connector arrows based on relative positions with new PathwayConnector
- Hook up cards and skeleton to use position-aware connectors

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6899f4acb87c8332b6cd60a385e5a223