### PR TITLE
feat: allow custom hobbies and improve mobile layout

### DIFF
--- a/src/components/ProgressTimeline.tsx
+++ b/src/components/ProgressTimeline.tsx
@@ -86,7 +86,7 @@ const ProgressTimeline: React.FC<ProgressTimelineProps> = ({ steps }) => {
   };
 
   return (
-    <div className="fixed left-8 top-24 bottom-24 w-8 z-10">
+    <div className="hidden md:block fixed left-8 top-24 bottom-24 w-8 z-10">
       <div className="relative h-full w-2 bg-indigo-100 rounded-full">
         <div
           className="absolute left-0 top-0 w-full bg-indigo-600 rounded-full transition-all duration-300 ease-out"

--- a/src/components/TagSelector.tsx
+++ b/src/components/TagSelector.tsx
@@ -9,8 +9,15 @@ interface TagSelectorProps {
   onNext: () => void;
 }
 
-const TagSelector: React.FC<TagSelectorProps> = ({ label, suggestions, onChange, onNext }) => {
+const TagSelector: React.FC<TagSelectorProps> = ({
+  label,
+  suggestions,
+  onChange,
+  onNext,
+}) => {
   const [selectedTags, setSelectedTags] = useState<string[]>([]);
+  const [availableTags, setAvailableTags] = useState<string[]>(suggestions);
+  const [customTag, setCustomTag] = useState("");
 
   const toggleTag = (tag: string) => {
     setSelectedTags((prev) => {
@@ -19,6 +26,19 @@ const TagSelector: React.FC<TagSelectorProps> = ({ label, suggestions, onChange,
       onChange(updated);
       return updated;
     });
+  };
+
+  const addCustomTag = () => {
+    const tag = customTag.trim();
+    if (!tag) return;
+    setAvailableTags((prev) => (prev.includes(tag) ? prev : [...prev, tag]));
+    setSelectedTags((prev) => {
+      if (prev.includes(tag)) return prev;
+      const updated = [...prev, tag];
+      onChange(updated);
+      return updated;
+    });
+    setCustomTag("");
   };
 
   return (
@@ -32,7 +52,7 @@ const TagSelector: React.FC<TagSelectorProps> = ({ label, suggestions, onChange,
       </motion.h2>
 
       <div className="flex flex-wrap justify-center gap-3 mb-6">
-        {suggestions.map((tag) => (
+        {availableTags.map((tag) => (
           <button
             key={tag}
             onClick={() => toggleTag(tag)}
@@ -45,6 +65,24 @@ const TagSelector: React.FC<TagSelectorProps> = ({ label, suggestions, onChange,
             {tag}
           </button>
         ))}
+      </div>
+
+      <div className="flex w-full gap-2 mb-6">
+        <input
+          type="text"
+          value={customTag}
+          onChange={(e) => setCustomTag(e.target.value)}
+          onKeyDown={(e) => e.key === "Enter" && addCustomTag()}
+          placeholder="Add a hobby"
+          className="flex-1 px-4 py-2 border rounded-full"
+        />
+        <button
+          type="button"
+          onClick={addCustomTag}
+          className="px-4 py-2 bg-indigo-600 text-white rounded-full"
+        >
+          Add
+        </button>
       </div>
 
       <button

--- a/src/components/TripStepCard.tsx
+++ b/src/components/TripStepCard.tsx
@@ -22,7 +22,7 @@ const TripStepCard: React.FC<TripStepCardProps> = ({
 }) => {
   return (
     <motion.div
-      className="bg-white rounded-2xl shadow-lg overflow-hidden w-72 sm:w-80"
+      className="bg-white rounded-2xl shadow-lg overflow-hidden w-full sm:w-80"
       initial={{ opacity: 0, y: 20 }}
       animate={{ opacity: 1, y: 0 }}
       transition={{ duration: 0.5 }}

--- a/src/components/TripStepCardSkeleton.tsx
+++ b/src/components/TripStepCardSkeleton.tsx
@@ -3,7 +3,7 @@ import React from "react";
 
 const TripStepCardSkeleton: React.FC = () => {
   return (
-    <div className="bg-white rounded-2xl shadow-lg overflow-hidden w-72 sm:w-80 animate-pulse">
+    <div className="bg-white rounded-2xl shadow-lg overflow-hidden w-full sm:w-80 animate-pulse">
       <div className="w-full h-40 bg-gray-200" />
       <div className="p-4 space-y-3">
         <div className="h-3 w-1/3 bg-gray-200 rounded" />

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -85,7 +85,7 @@ const Home: React.FC = () => {
   };
 
   return (
-    <div className="w-3/4 mx-auto py-20 px-4 relative flex flex-col items-center justify-center">
+    <div className="w-full md:w-3/4 mx-auto py-10 md:py-20 px-4 relative flex flex-col items-center justify-center">
       {step > 1 && step <= 4 && (
         <button
           onClick={handleBack}
@@ -96,8 +96,8 @@ const Home: React.FC = () => {
         </button>
       )}
 
-      <h1 className="text-5xl font-extrabold text-center mb-2">Trip Creator</h1>
-      <p className="text-4xl font-bold mb-8 text-center">Plan Your Perfect Trip</p>
+      <h1 className="text-3xl md:text-5xl font-extrabold text-center mb-2">Trip Creator</h1>
+      <p className="text-2xl md:text-4xl font-bold mb-8 text-center">Plan Your Perfect Trip</p>
 
       {/* Display chosen details */}
       <div className="flex flex-wrap gap-3 mb-8 justify-center">
@@ -189,7 +189,7 @@ const Home: React.FC = () => {
           {/* Sticky top-right button */}
           <button
             onClick={handleReset}
-            className="fixed top-20 right-20 z-50 px-6 py-3 bg-indigo-600 text-white font-semibold rounded-xl shadow-md hover:bg-indigo-700 transition"
+            className="fixed top-4 right-4 md:top-20 md:right-20 z-50 px-6 py-3 bg-indigo-600 text-white font-semibold rounded-xl shadow-md hover:bg-indigo-700 transition"
           >
             Start New Trip
           </button>


### PR DESCRIPTION
## Summary
- let users add custom hobbies to TagSelector
- adjust layout and components for better mobile experience

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a3024260ac8332bda416ff223b49ce