### PR TITLE
fix: reposition new trip button on mobile

### DIFF
--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -178,10 +178,10 @@ const Home: React.FC = () => {
 
       {step === 5 && (
         <>
-          {/* Sticky top-right button */}
+          {/* Sticky action button repositioned for mobile */}
           <button
             onClick={handleReset}
-            className="fixed top-4 right-4 md:top-20 md:right-20 z-50 px-6 py-3 bg-indigo-600 text-white font-semibold rounded-xl shadow-md hover:bg-indigo-700 transition"
+            className="fixed bottom-4 right-4 md:top-20 md:right-20 md:bottom-auto z-50 px-6 py-3 bg-indigo-600 text-white font-semibold rounded-xl shadow-md hover:bg-indigo-700 transition"
           >
             Start New Trip
           </button>


### PR DESCRIPTION
## Summary
- move "Start New Trip" button to the bottom right on small screens to avoid overlapping title

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a318a2c1208332852738c6c8af1894