### PR TITLE
Add map view with geocoded trip steps

### DIFF
--- a/src/api/geocode.ts
+++ b/src/api/geocode.ts
@@ -1,0 +1,33 @@
+// src/api/geocode.ts
+// Simple wrapper around Google Maps Geocoding API
+// Returns latitude and longitude for a given location string
+
+export interface GeocodeResult {
+  lat: number;
+  lng: number;
+}
+
+export async function geocodeLocation(location: string): Promise<GeocodeResult | null> {
+  const apiKey = import.meta.env.VITE_GOOGLE_MAPS_API_KEY;
+  if (!apiKey) {
+    console.error('Missing Google Maps API key');
+    return null;
+  }
+  try {
+    const res = await fetch(
+      `https://maps.googleapis.com/maps/api/geocode/json?address=${encodeURIComponent(location)}&key=${apiKey}`
+    );
+    if (!res.ok) {
+      throw new Error('Geocoding request failed');
+    }
+    const data = await res.json();
+    const first = data.results?.[0];
+    if (!first) return null;
+    const { lat, lng } = first.geometry.location;
+    return { lat, lng };
+  } catch (err) {
+    console.error('Geocoding error:', err);
+    return null;
+  }
+}
+

--- a/src/components/MapView.tsx
+++ b/src/components/MapView.tsx
@@ -1,0 +1,58 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+// src/components/MapView.tsx
+import React, { useEffect, useRef } from "react";
+
+interface GeocodedStep {
+  title: string;
+  location: string;
+  coordinates?: { lat: number; lng: number } | null;
+}
+
+interface MapViewProps {
+  steps: GeocodedStep[];
+  onMarkerClick?: (index: number) => void;
+}
+
+const MapView: React.FC<MapViewProps> = ({ steps, onMarkerClick }) => {
+  const mapRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    const initMap = () => {
+      if (!mapRef.current) return;
+      const googleObj = (window as any).google;
+      const firstCoords = steps.find((s) => s.coordinates)?.coordinates || {
+        lat: 0,
+        lng: 0,
+      };
+      const map = new googleObj.maps.Map(mapRef.current, {
+        center: firstCoords,
+        zoom: 12,
+      });
+
+      steps.forEach((step, idx) => {
+        if (!step.coordinates) return;
+        const marker = new googleObj.maps.Marker({
+          position: step.coordinates,
+          map,
+          title: step.title,
+        });
+        marker.addListener("click", () => onMarkerClick?.(idx));
+      });
+    };
+
+    if ((window as any).google?.maps) {
+      initMap();
+    } else {
+      const script = document.createElement("script");
+      script.src = `https://maps.googleapis.com/maps/api/js?key=${import.meta.env.VITE_GOOGLE_MAPS_API_KEY}`;
+      script.async = true;
+      script.onload = initMap;
+      document.head.appendChild(script);
+    }
+  }, [steps, onMarkerClick]);
+
+  return <div className="w-full h-96" ref={mapRef} />;
+};
+
+export default MapView;
+


### PR DESCRIPTION
## Summary
- add geocode API wrapper for Google Maps
- create MapView component showing markers for trip steps
- geocode and cache locations when generating trips
- render interactive map and highlight step cards from markers

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a47adbcb6483328936a1f80887719b